### PR TITLE
Rewind request stream to keep it available for slim request handler.

### DIFF
--- a/src/SwooleServerRequestConverter.php
+++ b/src/SwooleServerRequestConverter.php
@@ -48,13 +48,15 @@ final class SwooleServerRequestConverter
         // swoole $swooleRequest->rawContent return string
         /** @var string $content */
         $content = is_string($swooleRequest->rawContent()) ? $swooleRequest->rawContent() : '';
+        $stream = $this->streamFactory->createStream($content);
+        $stream->rewind();
 
         return $serverRequest
             ->withProtocolVersion($this->parseProtocol($server))
             ->withCookieParams($swooleRequest->cookie ?? [])
             ->withQueryParams($swooleRequest->get ?? [])
             ->withParsedBody($swooleRequest->post ?? [])
-            ->withBody($this->streamFactory->createStream($content))
+            ->withBody($stream)
             ->withUploadedFiles($this->parseUploadedFiles($swooleRequest->files ?? []));
     }
 


### PR DESCRIPTION
Hello,

I noticed a problem while retrieving request body contents on Slim request handler. The body was always coming empty (`[]`). After some investigation it was just a matter of rewinding the request body stream. I'm not sure if this happens to everybody, but this happened consistently for me on Ubuntu 21.10, PHP 8.1 with Swoole 4.8.6.

Let me know if there is any concern related to this change. 